### PR TITLE
Enable Pylint and Bandit static checkers in Actions

### DIFF
--- a/.github/workflows/lints.yaml
+++ b/.github/workflows/lints.yaml
@@ -1,6 +1,11 @@
 name: Lints
 
 on:
+  schedule:
+    # Run each Sun
+    - cron: '0 0 * * 0'
+  push:
+  pull_request:
   workflow_dispatch:
 
 jobs:
@@ -9,10 +14,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3.5.0
-      - uses: ricardochaves/python-lint@v1.4.0
-        with:
-          use-pycodestyle: false
-          use-flake8: false
-          use-black: false
-          use-mypy: false
-          use-isort: false
+      - run: |
+          pip install -r requirements.txt
+          pip install pylint bandit
+          pylint src/swin
+          bandit -r src/swin

--- a/.github/workflows/lints.yaml
+++ b/.github/workflows/lints.yaml
@@ -14,8 +14,16 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3.5.0
-      - run: |
-          pip install -r requirements.txt
-          pip install pylint bandit
+  
+      - name: Install dependencies
+        run: pip install -r requirements.txt
+
+      - name: Run Pylint static code analyser
+        run: |
+          pip install pylint
           pylint src/swin
+
+      - name: Run Bandit security analyser
+        run: |
+          pip install bandit
           bandit -r src/swin

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,10 @@ build-backend = "hatchling.build"
 
 [project]
 name = "swin"
-dynamic = ["version"]
+dynamic = [
+    "version",
+    "dependencies"
+]
 authors = [
   { name="Serge Lunev" },
 ]
@@ -16,14 +19,6 @@ classifiers = [
     "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
 ]
-dependencies = [
-  "matplotlib>=3.7.1",
-  "numerize>=0.12",
-  "numpy>=1.24.2",
-  "pandas>=1.5.3",
-  "prettytable>=3.6.0",
-  "pypistats>=1.2.1",
-]
 
 [project.urls]
 "Homepage" = "https://github.com/lunarserge/swin"
@@ -34,3 +29,6 @@ swin = "swin.swin:main"
 
 [tool.hatch.version]
 path = "src/swin/swin.py"
+
+[tool.setuptools.dynamic]
+dependencies = {file = ["requirements.txt"]}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,6 @@
+  matplotlib>=3.7.1
+  numerize>=0.12
+  numpy>=1.24.2
+  pandas>=1.5.3
+  prettytable>=3.6.0
+  pypistats>=1.2.1

--- a/src/swin/swin.py
+++ b/src/swin/swin.py
@@ -49,7 +49,8 @@ def main():
     args = parser.parse_args()
 
     ref = args.ref
-    if ref: ref = PyPIPackage(ref)
+    if ref:
+        ref = PyPIPackage(ref)
     packages = [PyPIPackage(p, ref=ref) for p in args.package]
 
     for package in packages:


### PR DESCRIPTION
Decided not to use pre-made ricardochaves/python-lint action and install checkers directly since pre-made action uses a docker image with checkers inside that 1) does not let me install my dependencies into it and 2) checkers versions are outdated